### PR TITLE
verify HTTPS certificate by default

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,3 +36,21 @@ Removing bugs:
     if need_refresh:
         print('refreshing')
         e.refresh()
+
+SSL errors
+----------
+
+This library verifies the ET server's HTTPS certificate by default. This is
+more of a python-requests thing, but if you receive an SSL verification error,
+it's probably because you don't have the Red Hat IT CA set up for your Python
+environment. Particularly if you're running this in a virtualenv, you'll want
+to set the following configuration variable::
+
+    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/source/anchors/RH-IT-Root-CA.crt
+
+Where "RH-IT-Root-CA.crt" is the public cert that signed the Chacra server's
+HTTPS certificate.
+
+When using RHEL 7's python-requests RPM, requests simply checks
+``/etc/pki/tls/certs/ca-bundle.crt``, so you'll need to add the IT CA cert to
+that big bundle file.

--- a/errata_tool/connector.py
+++ b/errata_tool/connector.py
@@ -7,7 +7,7 @@ from jsonpath_rw import parse
 class ErrataConnector:
     _url = "https://errata.devel.redhat.com"
     _auth = HTTPKerberosAuth()
-    ssl_verify = False  # Shared
+    ssl_verify = True  # Shared
 
     # Simple wrappers to avoid copying around when auth changes.
     def _post(self, url, **kwargs):

--- a/errata_tool/security.py
+++ b/errata_tool/security.py
@@ -5,7 +5,7 @@ import urllib3.exceptions as exceptions  # NOQA
 
 class SecurityParameters():
     _warnings_disabled = False
-    _verify_ssl = False
+    _verify_ssl = True
 
     def __init__(self):
         if self._warnings_disabled is False and self._verify_ssl is False:

--- a/errata_tool/security.py
+++ b/errata_tool/security.py
@@ -14,6 +14,8 @@ class SecurityParameters():
             # urllib3.disable_warnings()
             # urllib3.disable_warnings(category=exceptions.SecurityWarning)
             # urllib3.disable_warnings(category=exceptions.InsecureRequestWarning)
+            # prod cert lacks subjectAltName
+            urllib3.disable_warnings(r'Certificate has no `subjectAltName`, falling back to check for a `commonName` for now') # NOQA
             warnings.filterwarnings('ignore')
 
     def __str__(self):

--- a/errata_tool/tests/test_init.py
+++ b/errata_tool/tests/test_init.py
@@ -1,6 +1,20 @@
 import errata_tool
+from errata_tool import ErrataConnector, security
 
 
 class TestInit(object):
     def test_init(self):
         assert errata_tool
+
+
+class TestSecurity(object):
+    def test_ssl_default(self):
+        """ Ensure that we verify SSL by default. """
+        assert security.security_settings.ssl_verify()
+
+
+class TestErratum(object):
+    def test_ssl_default(self):
+        """ Ensure that we verify SSL by default. """
+        e = ErrataConnector()
+        assert e.ssl_verify


### PR DESCRIPTION
Prior to this change, the errata-tool lib disabled requests' SSL verification by default. (I assume this was done for the sake of ease-of-use, or maybe some non-prod host did not have a working cert.)

To improve security, enable SSL verification by default instead.

Add tests to ensure this behavior going forward.

Add documentation to the README for users to trust the root CA.

When SSL verification is enabled, requests prints a warning about a missing subjectAltName extension. Silence this warning (a server-side fix is in progress).