### PR TITLE
.travis.yml: fix urllib3 install during tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ install:
     #   virtualenv.
   - pip install pytest-flake8
   - pip install pytest-cov python-coveralls
+    # We must explicitly install urllib3 into the virtualenv using pip here,
+    # because setuptools' EasyInstall is not always able to install some
+    # versions of urllib3. Partially explained here:
+    # https://github.com/shazow/urllib3/issues/986
+  - pip install urllib3
 script:
   - python setup.py test -v -a "--cov-config .coveragerc --cov=errata_tool"
 after_success:


### PR DESCRIPTION
The "python setup.py test" command uses EasyInstall to install
dependencies, and the latest versions of urllib3 will fail to install
with EasyInstall:

    error: Setup script exited with error in urllib3 setup command: Invalid
    environment marker: python_version <= "2.7"

Use pip to install urllib3 instead.