### PR TITLE
erratum: check if under embargo or not

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -180,6 +180,15 @@ https://access.redhat.com/articles/11258")
             self.errata_state = v.encode('ascii', 'ignore')
             self._original_state = self.errata_state
 
+            # Check if the erratum is under embargo
+            self.embargoed = False
+            self.release_date = erratum['release_date']
+            if self.release_date is not None:
+                cur = datetime.datetime.utcnow()
+                cur = str(cur).split()[0]
+                if self.release_date > cur:
+                    self.embargoed = True
+
             # Ship date
             d = erratum['publish_date_override']
             if d is not None:


### PR DESCRIPTION
From Jarod Wilson <jarod@redhat.com>

The kernel team has need to query the kernel errata to check if the latest kernel build is under embargo. Discussion with folks on the errata-tools team revealed that this is conveyed by an erratum having the release_date field set, with a date that is in the future. This just adds a check for release_date, and compares it with the current date, copies the release_date field and sets an embargoed flag in Erratum, both of which can be consumed by scripts using this library.