### PR TITLE
flake8: fix recent error in security.py

### DIFF
--- a/errata_tool/security.py
+++ b/errata_tool/security.py
@@ -25,4 +25,5 @@ class SecurityParameters():
     def ssl_verify(self):
         return self._verify_ssl
 
+
 security_settings = SecurityParameters()


### PR DESCRIPTION
flake8 3.1.1 surfaces the following issue:

```
errata_tool/security.py:28:1: E305 expected 2 blank lines after class or
function definition, found 1
```