### PR TITLE
drop the re-dundant and mis-leading guard in Erratum.update()

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -54,9 +54,6 @@ class Erratum(ErrataConnector):
         self.current_flags = []
 
     def update(self, **kwargs):
-        if self.errata_state != 'NEW_FILES':
-            raise ErrataException('Can\'t update errata fields if not ' +
-                                  'in NEW_FILES state')
         if 'errata_type' in kwargs:
             self.errata_type = kwargs['errata_type']
             self._update = True


### PR DESCRIPTION
Guard was checking to make sure advisory was NEW_FILES before
it would attempt to change anything.  This appears to be a
legacy check that is no-longer needed.

Tested with:

publish_date_override changes in state == ON_QE
==> Update publish_date_override

update bugs while in state == ON_QE throws exception
==> errata_tool.exception.ErrataException: Erratum 26134: idsfixed: Errata Cannot remove non-security Bugs unless in NEW_FILES state