### PR TITLE
support setting QE group

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,6 +31,7 @@ Creating a new advisory:
                 description='This update contains the following fixes ...',
                 solution='Before applying this update...',
                 qe_email='someone@redhat.com',
+                qe_group='RHC (Ceph) QE',
                 errata_type='RHBA',
                 owner_email='kdreyer@redhat.com',
                 manager_email='ohno@redhat.com',

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -614,8 +614,8 @@ https://access.redhat.com/articles/11258")
 
         if self.qe_email is not None:
             pdata['advisory[assigned_to_email]'] = self.qe_email
-        # if self.qe_group is not None:
-        #     pdata['advisory[assigned_to]'] = self.qe_group
+        if self.qe_group is not None:
+            pdata['advisory[quality_responsibility_name]'] = self.qe_group
 
         if self.synopsis is None:
             raise ErrataException("Can't write erratum without synopsis")


### PR DESCRIPTION
The ET supports setting the QE group during advisory creations and updates with the new `quality_responsibility_name` parameter.

https://bugzilla.redhat.com/1386089

Support this in our library as well.