### PR TITLE
README: fix url() example output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Example:
     # prints "NEW_FILES"
 
     print(e.url())
-    # prints "https://errata.devel.redhat.com/errata/1234"
+    # prints "https://errata.devel.redhat.com/advisory/1234"
 
 Creating a new advisory:
 


### PR DESCRIPTION
The `url()` method returns the `/advisory/<id>` endpoint.

(The `/errata/<id>` is wrong, and in fact it's a 404 error server-side.)