### PR TITLE
erratum: do not decode errata status

### DIFF
--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -175,9 +175,8 @@ https://access.redhat.com/articles/11258")
                 break
 
             self.errata_id = erratum['id']
-            # NEW_FILES QE etc. - decode from unicode
-            v = erratum['status']
-            self.errata_state = v.encode('ascii', 'ignore')
+            # NEW_FILES QE etc.
+            self.errata_state = erratum['status']
             self._original_state = self.errata_state
 
             # Check if the erratum is under embargo


### PR DESCRIPTION
Take the status value from the JSON as-is. No need to decode the value.

This fixes an error on Python 3 where this decode() call would change
the value to a bytes type, which caused further errors in _fetch() when
trying to compare that bytes value with strings like 'QE'.