### PR TITLE
rpm: always build python2 package

### DIFF
--- a/python-errata-tool.spec
+++ b/python-errata-tool.spec
@@ -18,16 +18,13 @@ Source0:        %{pkgname}-%{version}.tar.gz
 
 BuildArch:      noarch
 %if 0%{?with_python3}
-Requires:  python3-requests-kerberos
-Requires:  python3-jsonpath-rw
-Requires:  python3-six
 BuildRequires:  python3-devel
 BuildRequires:  python3-jsonpath-rw
 BuildRequires:  python3-pytest
 BuildRequires:  python3-requests-kerberos
 BuildRequires:  python3-setuptools
 BuildRequires:  python3-six
-%else # python 2
+%endif
 Requires:  python-requests-kerberos
 Requires:  python-jsonpath-rw
 Requires:  python-six
@@ -37,46 +34,65 @@ BuildRequires:  python-jsonpath-rw
 BuildRequires:  python-requests-kerberos
 BuildRequires:  python-setuptools
 BuildRequires:  python-six
-%endif
 
 %description
 Modern Python API to Red Hat's Errata Tool
 
+
+%if 0%{?with_python3}
+%package -n python3-%{pkgname}
+Summary:    %{summary}
+Requires:   python3 >= 3.5
+Requires:   python3-requests-kerberos
+Requires:   python3-jsonpath-rw
+Requires:   python3-six
+
+%description -n python3-%{pkgname}
+Modern Python API to Red Hat's Errata Tool
+%endif # with_python3
+
+
 %prep
 %setup -q -n %{pkgname}-%{version}
 
+%if 0%{?with_python3}
+cp -a . %{py3dir}
+%endif # with_python3
+
 %build
+%{__python2} setup.py build
 
 %if 0%{?with_python3}
-%{__python3} setup.py build
-%else
-%{__python2} setup.py build
+%{py3_build}
 %endif # with_python3
 
 %install
-%if 0%{?with_python3}
-%{__python3} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
-%else
 %{__python2} setup.py install -O1 --skip-build --root $RPM_BUILD_ROOT
-%endif
+%if 0%{?with_python3}
+%py3_install
+%endif # with_python3
 
 %check
 export PYTHONPATH=$(pwd)
+py.test-%{python_version} -v errata_tool/tests
 
 %if 0%{?with_python3}
+pushd %{py3dir}
 py.test-%{python3_version} -v errata_tool/tests
-%else
-py.test-%{python_version} -v errata_tool/tests
-%endif
+popd
+%endif # with_python3
 
 %files
 %{!?_licensedir:%global license %%doc}
 %doc README.rst
 %license LICENSE
-%if 0%{?with_python3}
-%{python3_sitelib}/*
-%else
 %{python2_sitelib}/*
+
+%if 0%{?with_python3}
+%files -n python3-%{pkgname}
+%doc README.rst
+%license LICENSE
+%{python3_sitelib}/*
 %endif # with_python3
 
 


### PR DESCRIPTION
Prior to this change, the RPM .spec would only build the python3 subpackage on Fedora.

Build both python2 and python3 subpackages on Fedora so that errata-tool can be integrated with other py2 libraries and scripts.