### PR TITLE
add changeDocsReviewer()

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -101,6 +101,14 @@ Changing state:
 
     e.setState('QE')
 
+Changing docs reviewer:
+
+.. code-block:: python
+
+    e = Erratum(errata_id=24075)
+
+    e.changeDocsReviewer('kdreyer@redhat.com')
+
 
 Using the staging server
 ------------------------

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -464,6 +464,12 @@ https://access.redhat.com/articles/11258")
     def findMissingBuilds(self):
         raise NotImplementedError('RHOS-only method')
 
+    def changeDocsReviewer(self, login_name):
+        val = {'login_name': login_name}
+        url = '/api/v1/erratum/%d/change_docs_reviewer' % self.errata_id
+        r = self._post(url, data=val)
+        self._processResponse(r)
+
     #
     # Flag list could be replaced with a set at some
     # point.

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -59,6 +59,11 @@ def mock_get():
 
 
 @pytest.fixture
+def mock_post():
+    return RequestRecorder()
+
+
+@pytest.fixture
 def advisory(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)

--- a/errata_tool/tests/conftest.py
+++ b/errata_tool/tests/conftest.py
@@ -43,15 +43,23 @@ class MockResponse(object):
             raise
 
 
-def mock_get(url, **kwargs):
-    """ mocking requests.get() """
-    m = MockResponse()
-    m.url = url
-    return m
+class RequestRecorder(object):
+    """ Record args to requests.get() or requests.post() """
+    def __call__(self, url, **kwargs):
+        """ mocking requests.get() or requests.post() """
+        self.response = MockResponse()
+        self.response.url = url
+        self.kwargs = kwargs
+        return self.response
 
 
 @pytest.fixture
-def advisory(monkeypatch):
+def mock_get():
+    return RequestRecorder()
+
+
+@pytest.fixture
+def advisory(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(requests, 'get', mock_get)
@@ -59,7 +67,7 @@ def advisory(monkeypatch):
 
 
 @pytest.fixture
-def productlist(monkeypatch):
+def productlist(monkeypatch, mock_get):
     monkeypatch.delattr('requests.sessions.Session.request')
     monkeypatch.setattr(ErrataConnector, '_auth', None)
     monkeypatch.setattr(requests, 'get', mock_get)

--- a/errata_tool/tests/test_change_docs_reviewer.py
+++ b/errata_tool/tests/test_change_docs_reviewer.py
@@ -1,0 +1,14 @@
+import requests
+
+
+class TestChangeDocsReviewer(object):
+
+    def test_change_url(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.changeDocsReviewer('kdreyer@redhat.com')
+        assert mock_post.response.url == 'https://errata.devel.redhat.com/api/v1/erratum/26175/change_docs_reviewer'  # NOQA: E501
+
+    def test_change_data(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.changeDocsReviewer('kdreyer@redhat.com')
+        assert mock_post.kwargs['data'] == {'login_name': 'kdreyer@redhat.com'}


### PR DESCRIPTION
Add a method to change an advisory's docs reviewer.

Refactor the GET mocking code to a proper pytest fixture with a call recorder. Also add `mock_post` fixture so we can mock APIs to which we must POST.