### PR TITLE
erratum: new addCC() method

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -109,6 +109,14 @@ Changing docs reviewer:
 
     e.changeDocsReviewer('kdreyer@redhat.com')
 
+Adding someone to the CC list:
+
+.. code-block:: python
+
+    e = Erratum(errata_id=24075)
+
+    e.addCC('kdreyer@redhat.com')
+
 
 Using the staging server
 ------------------------

--- a/errata_tool/erratum.py
+++ b/errata_tool/erratum.py
@@ -493,6 +493,13 @@ https://access.redhat.com/articles/11258")
         r = self._post(url, data=val)
         self._processResponse(r)
 
+    def addCC(self, email):
+        """ Add someone to the CC list for this advisory. """
+        val = {'id': self.errata_id, 'email': email}
+        url = '/carbon_copies/add_to_cc_list'
+        r = self._post(url, data=val)
+        self._processResponse(r)
+
     #
     # Flag list could be replaced with a set at some
     # point.

--- a/errata_tool/tests/test_add_cc.py
+++ b/errata_tool/tests/test_add_cc.py
@@ -1,0 +1,15 @@
+import requests
+
+
+class TestAddCC(object):
+
+    def test_add_cc_url(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.addCC('kdreyer@redhat.com')
+        assert mock_post.response.url == 'https://errata.devel.redhat.com/carbon_copies/add_to_cc_list'  # NOQA: E501
+
+    def test_add_cc_data(self, monkeypatch, mock_post, advisory):
+        monkeypatch.setattr(requests, 'post', mock_post)
+        advisory.addCC('kdreyer@redhat.com')
+        expected = {'id': 26175, 'email': 'kdreyer@redhat.com'}
+        assert mock_post.kwargs['data'] == expected


### PR DESCRIPTION
Use this to add someone to the CC list for an advisory.

This method is not documented in the ET's API docs - I just traced what the Javascript / HTML form was doing in Chrome.